### PR TITLE
fix: increase max memory restart to 64MB

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -5,7 +5,7 @@ module.exports = {
       script: "./dist/index.js",
       instances: 4,
       exp_backoff_restart_delay: 100,
-      max_memory_restart: "32M",
+      max_memory_restart: "64M",
       watch: ["./script/script.js"],
       watch_options: {
         followSymlinks: false,


### PR DESCRIPTION
```
2020-11-04T10:52:49: PM2 log: -softReload- New worker listening
2020-11-04T10:52:57: PM2 log: Stopping app:dgraph-lambda id:_old_1
2020-11-04T10:52:57: PM2 log: App name:dgraph-lambda id:_old_1 disconnected
2020-11-04T10:52:57: PM2 log: App [dgraph-lambda:_old_1] exited with code [0] via signal [SIGINT]
2020-11-04T10:52:57: PM2 log: App [dgraph-lambda:_old_1] will restart in 100ms
2020-11-04T10:52:57: PM2 log: pid=65 msg=process killed
2020-11-04T10:52:57: PM2 log: [PM2][WORKER] Reset the restart delay, as app dgraph-lambda has been up for more than 30000ms
2020-11-04T10:52:57: PM2 log: [PM2][WORKER] Process 2 restarted because it exceeds --max-memory-restart value (current_memory=46522368 max_memory_limit=33554432 [octets])
2020-11-04T10:52:57: PM2 log: App [dgraph-lambda:2] starting in -cluster mode-
2020-11-04T10:52:57: PM2 log: App [dgraph-lambda:2] online
```