### PR TITLE
feat: Add support for webhook

### DIFF
--- a/slash-graphql-lambda-types/types.d.ts
+++ b/slash-graphql-lambda-types/types.d.ts
@@ -9,11 +9,43 @@ declare module "@slash-graphql/lambda-types" {
     value: string | undefined
   }
 
+  type eventPayload = {
+    __typename: string,
+    operation: string,
+    commitTs: number,
+    add: addEvent | undefined,
+    update: updateEvent | undefined,
+    delete: deleteEvent | undefined
+  }
+
+
+  type addEvent = {
+    add: {
+      rootUIDs: Array<any>,  
+      input: Array<any>
+    } 
+  }
+
+  type updateEvent = {
+    update: {
+      rootUIDs: Array<any>,
+      SetPatch: Object,
+      RemovePatch: Object
+    } 
+  }
+
+  type deleteEvent = {
+    delete: {
+      rootUIDs: Array<any>
+    } 
+  }
+
   type GraphQLEventFields = {
     type: string,
     parents: (Record<string, any>)[] | null,
     args: Record<string, any>,
-    authHeader?: AuthHeaderField
+    authHeader?: AuthHeaderField,
+    event?: eventPayload
   }
 
   type ResolverResponse = any[] | Promise<any>[] | Promise<any[]>;
@@ -27,12 +59,27 @@ declare module "@slash-graphql/lambda-types" {
     },
   }
 
+  type WebHookGraphQLEvent = {
+    respondWith: (r: ResolverResponse) => void,
+    graphql: (s: string, vars: Record<string, any> | undefined, ah?: AuthHeaderField) => Promise<GraphQLResponse>,
+    dql: {
+      query: (s: string, vars: Record<string, any> | undefined) => Promise<GraphQLResponse>
+      mutate: (s: string) => Promise<GraphQLResponse>
+    },
+    authHeader?: AuthHeaderField,
+    event?: eventPayload
+  } 
+
   type GraphQLEventWithParent = GraphQLEvent & {
     parent: Record<string, any> | null
   }
 
   function addGraphQLResolvers(resolvers: {
     [key: string]: (e: GraphQLEventWithParent) => any;
+  }): void
+
+  function addWebHookResolvers(resolvers: {
+    [key: string]: (e: WebHookGraphQLEvent) => any;
   }): void
 
   function addMultiParentGraphQLResolvers(resolvers: {

--- a/slash-graphql-lambda-types/types.d.ts
+++ b/slash-graphql-lambda-types/types.d.ts
@@ -50,25 +50,25 @@ declare module "@slash-graphql/lambda-types" {
 
   type ResolverResponse = any[] | Promise<any>[] | Promise<any[]>;
 
-  type GraphQLEvent = GraphQLEventFields & {
-    respondWith: (r: ResolverResponse) => void,
-    graphql: (s: string, vars: Record<string, any> | undefined, ah?: AuthHeaderField) => Promise<GraphQLResponse>,
+  type GraphQLEventCommonFields = {
+    type: string;    
+    respondWith: (r: ResolverResponse) => void;
+    graphql: (s: string, vars: Record<string, any> | undefined, ah?: AuthHeaderField) => Promise<GraphQLResponse>;
     dql: {
-      query: (s: string, vars: Record<string, any> | undefined) => Promise<GraphQLResponse>
-      mutate: (s: string) => Promise<GraphQLResponse>
-    },
-  }
-
-  type WebHookGraphQLEvent = {
-    respondWith: (r: ResolverResponse) => void,
-    graphql: (s: string, vars: Record<string, any> | undefined, ah?: AuthHeaderField) => Promise<GraphQLResponse>,
-    dql: {
-      query: (s: string, vars: Record<string, any> | undefined) => Promise<GraphQLResponse>
-      mutate: (s: string) => Promise<GraphQLResponse>
-    },
-    authHeader?: AuthHeaderField,
-    event?: eventPayload
-  } 
+      query: (s: string, vars: Record<string, any> | undefined) => Promise<GraphQLResponse>;
+      mutate: (s: string) => Promise<GraphQLResponse>;
+    };
+    authHeader?: AuthHeaderField;
+  };
+  
+  type GraphQLEvent = GraphQLEventCommonFields & {
+    parents: Record<string, any>[] | null;
+    args: Record<string, any>;
+  };
+  
+  type WebHookGraphQLEvent = GraphQLEventCommonFields & {
+    event?: eventPayload;
+  }; 
 
   type GraphQLEventWithParent = GraphQLEvent & {
     parent: Record<string, any> | null

--- a/src/evaluate-script.ts
+++ b/src/evaluate-script.ts
@@ -91,7 +91,7 @@ export function evaluateScript(source: string) {
 
   return async function(e: GraphQLEventFields): Promise<any | undefined> {
     let retPromise: ResolverResponse | undefined = undefined;
-    let event = {
+    const event = {
       ...e,
       respondWith: (x: ResolverResponse) => { retPromise = x },
       graphql: (query: string, variables: Record<string, any>, ah?: AuthHeaderField) => graphql(query, variables, ah || e.authHeader),

--- a/src/evaluate-script.ts
+++ b/src/evaluate-script.ts
@@ -1,6 +1,6 @@
 import { EventTarget } from 'event-target-shim';
 import vm from 'vm';
-import { GraphQLEvent, GraphQLEventWithParent, GraphQLEventFields, ResolverResponse, AuthHeaderField } from '@slash-graphql/lambda-types'
+import { GraphQLEvent, GraphQLEventWithParent, GraphQLEventFields, ResolverResponse, AuthHeaderField, WebHookGraphQLEvent } from '@slash-graphql/lambda-types'
 
 import fetch, { Request, Response, Headers } from "node-fetch";
 import { URL } from "url";
@@ -29,6 +29,15 @@ class GraphQLResolverEventTarget extends EventTarget {
       this.addEventListener(name, e => {
         const event = e as unknown as GraphQLEvent;
         event.respondWith(getParents(event).map(parent => resolver({...event, parent})))
+      })
+    }
+  }
+
+  addWebHookResolvers(resolvers: { [key: string]: (e: WebHookGraphQLEvent) => (any | Promise<any>) }) {
+    for (const [name, resolver] of Object.entries(resolvers)) {
+      this.addEventListener(name, e => {
+        const event = e as unknown as WebHookGraphQLEvent;
+        event.respondWith(resolver(event))
       })
     }
   }
@@ -70,6 +79,7 @@ function newContext(eventTarget: GraphQLResolverEventTarget) {
     removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
     addMultiParentGraphQLResolvers: eventTarget.addMultiParentGraphQLResolvers.bind(eventTarget),
     addGraphQLResolvers: eventTarget.addGraphQLResolvers.bind(eventTarget),
+    addWebHookResolvers: eventTarget.addWebHookResolvers.bind(eventTarget),
   });
 }
 
@@ -81,11 +91,14 @@ export function evaluateScript(source: string) {
 
   return async function(e: GraphQLEventFields): Promise<any | undefined> {
     let retPromise: ResolverResponse | undefined = undefined;
-    const event = {
+    let event = {
       ...e,
       respondWith: (x: ResolverResponse) => { retPromise = x },
       graphql: (query: string, variables: Record<string, any>, ah?: AuthHeaderField) => graphql(query, variables, ah || e.authHeader),
       dql,
+    }
+    if (e.type === '$webhook' && e.event) {
+      event.type = `${e.event?.__typename}.${e.event?.operation}` 
     }
     target.dispatchEvent(event)
 
@@ -95,7 +108,7 @@ export function evaluateScript(source: string) {
 
     const resolvedArray = await (retPromise as ResolverResponse);
     if(!Array.isArray(resolvedArray) || resolvedArray.length !== getParents(e).length) {
-      process.env.NODE_ENV != "test" && console.error(`Value returned from ${e.type} was not an array or of incorrect length`)
+      process.env.NODE_ENV != "test" && e.type !== '$webhook' && console.error(`Value returned from ${e.type} was not an array or of incorrect length`)
       return undefined
     }
 

--- a/src/script-to-express.ts
+++ b/src/script-to-express.ts
@@ -8,6 +8,7 @@ function bodyToEvent(b: any): GraphQLEventFields {
     parents: b.parents || null,
     args: b.args || {},
     authHeader: b.authHeader,
+    event: b.event || {},
   }
 }
 


### PR DESCRIPTION
This PR enables support for webhook events coming from Dgraph. Check out this [PR](https://github.com/dgraph-io/dgraph/pull/7494) and the discuss [post](https://discuss.dgraph.io/t/webhook-lambda-on-add-update-delete-mutations/12904) for more info.

Now using `self.addWebHookResolvers` one can add resolvers for webhook events.

```js
async function hellowebhook({ dql, graphql, authHeader, event }) {
 ...
}

self.addWebHookResolvers({
  "User.add": hellowebhook,
})
```