### PR TITLE
Add info object type

### DIFF
--- a/slash-graphql-lambda-types/types.d.ts
+++ b/slash-graphql-lambda-types/types.d.ts
@@ -9,6 +9,27 @@ declare module "@slash-graphql/lambda-types" {
     value: string | undefined
   }
 
+  type InfoField = {
+    field: selectionField 
+  }
+
+  type selectionField = {
+    alias: string,
+    name: string,
+    arguments: Record<string, any>,
+    directives: fldDirectiveList,
+    selectionSet: selectionSet
+  }
+
+  type selectionSet = Array<selectionField>
+
+  type fldDirectiveList = Array<fldDirective>
+
+  type fldDirective = {
+    name: string,
+    arguments: Record<string, any>
+  }
+
   type eventPayload = {
     __typename: string,
     operation: string,
@@ -45,7 +66,8 @@ declare module "@slash-graphql/lambda-types" {
     parents: (Record<string, any>)[] | null,
     args: Record<string, any>,
     authHeader?: AuthHeaderField,
-    event?: eventPayload
+    event?: eventPayload,
+    info?: InfoField
   }
 
   type ResolverResponse = any[] | Promise<any>[] | Promise<any[]>;
@@ -64,6 +86,7 @@ declare module "@slash-graphql/lambda-types" {
   type GraphQLEvent = GraphQLEventCommonFields & {
     parents: Record<string, any>[] | null;
     args: Record<string, any>;
+    info: InfoField;
   };
   
   type WebHookGraphQLEvent = GraphQLEventCommonFields & {

--- a/src/script-to-express.ts
+++ b/src/script-to-express.ts
@@ -9,6 +9,7 @@ function bodyToEvent(b: any): GraphQLEventFields {
     args: b.args || {},
     authHeader: b.authHeader,
     event: b.event || {},
+    info: b.info || null,
   }
 }
 
@@ -21,6 +22,9 @@ export function scriptToExpress(source: string) {
       const result = await runner(bodyToEvent(req.body));
       if(result === undefined) {
         res.status(400)
+        if(req.body.resolver === '$webhook') {
+          res.status(200)
+        }
       }
       res.json(result)
     } catch(e) {

--- a/src/script-to-express.ts
+++ b/src/script-to-express.ts
@@ -20,11 +20,8 @@ export function scriptToExpress(source: string) {
   app.post("/graphql-worker", async (req, res, next) => {
     try {
       const result = await runner(bodyToEvent(req.body));
-      if(result === undefined) {
+      if(result === undefined && req.body.resolver !== '$webhook') {
         res.status(400)
-        if(req.body.resolver === '$webhook') {
-          res.status(200)
-        }
       }
       res.json(result)
     } catch(e) {


### PR DESCRIPTION
This PR adds support for passing `info` object and fixes the error code returned for webhook.

Example - 

```js
async function authorsByName({ args, dql, info }) {
    const results = await dql.query(
        `query queryAuthor($name: string, $numLikes: int) {
              queryAuthor(func: type(Author)) @filter(eq(Author.name, $name)) {
                  name: Author.name
                  dob: Author.dob
                  reputation: Author.reputation
                  posts: Author.posts @filter(eq(Post.numLikes,$numLikes)) { 
                     title: Post.title
                  }
              }
    }`,
        {
            $name: args.name,
            $numLikes: info.field.selectionSet[3].arguments.filter.numLikes.eq,
        },
    );
    return results.data.queryAuthor;
}
```

Use-case: https://discuss.dgraph.io/t/13179
Related Dgraph PR: https://github.com/dgraph-io/dgraph/pull/7718