### PR TITLE
add Uint8Array to vm context

### DIFF
--- a/src/evaluate-script.ts
+++ b/src/evaluate-script.ts
@@ -61,6 +61,7 @@ function newContext(eventTarget: GraphQLResolverEventTarget) {
 
     // Crypto
     crypto: new Crypto(),
+    Uint8Array,
     TextDecoder,
     TextEncoder,
 


### PR DESCRIPTION
this fixes an issue where `new TextEncoder().encode("test") instanceof Uint8Array` is false when it's expected to be true 