### PR TITLE
Use env variable to set max memory limit and instance number

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -3,9 +3,9 @@ module.exports = {
     {
       name: "dgraph-lambda",
       script: "./dist/index.js",
-      instances: 4,
+      instances: Number(process.env.INSTANCES || 4),
       exp_backoff_restart_delay: 100,
-      max_memory_restart: "64M",
+      max_memory_restart: process.env.MAX_MEMORY_LIMIT || "64M",
       watch: ["./script/script.js"],
       watch_options: {
         followSymlinks: false,


### PR DESCRIPTION
Max memory limit could be different based on the lambda resolver and sometimes it needs more memory so we should be able to set this via a environment variable.
The same is true for number of instances that PM2 creates.

[Discussion on Dgraph](https://discuss.dgraph.io/t/how-to-increase-dgraph-lambda-max-memory-limit/16401)