### PR TITLE
Add linux installs for npm

### DIFF
--- a/.github/workflows/cd-dgraph-lambda.yml
+++ b/.github/workflows/cd-dgraph-lambda.yml
@@ -24,7 +24,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD_TOKEN }}
-      - name: Push dgraph-lambda images
+      - name: Install linux dependencies
+        run: |
+          #!/bin/bash
+          apt-get update -y 
+          apt-get install qemu qemu-user-static binfmt-support debootstrap -y          
+      - name: Build and push dgraph-lambda images
         run: |
           docker buildx create --name builder --driver docker-container
           docker buildx use builder


### PR DESCRIPTION
# Problem #
Lambda cd was failing due to lack of some linux dependencies for `run npm`

# Solution #
Adding apt-get update and apt-get installs to fix this in the CD steps according to: https://stackoverflow.com/questions/67017795/npm-install-is-failing-with-docker-buildx-linux-arm64