### PR TITLE
fix(cd): Update cd process to push manifests instead of using buildx

### DIFF
--- a/.github/workflows/cd-dgraph-lambda.yml
+++ b/.github/workflows/cd-dgraph-lambda.yml
@@ -30,8 +30,9 @@ jobs:
           sudo apt-get update -y
           # buildx requires these base linux packages to run npm install
           sudo apt-get install qemu qemu-user-static binfmt-support debootstrap -y        
-      - name: Build and push dgraph-lambda images
+      - name: Build and push dgraph-lambda image manifest
         run: |
-          docker buildx create --name builder --driver docker-container
-          docker buildx use builder
-          docker buildx build -t dgraph/dgraph-lambda:${{ env.DGRAPH_LAMBDA_RELEASE_VERSION }} -t dgraph/dgraph-lambda:latest --push --platform=linux/arm64,linux/amd64 .
+          docker manifest create dgraph-lambda:${{ env.DGRAPH_LAMBDA_RELEASE_VERSION }} --amend dgraph-lambda:${{ env.DGRAPH_LAMBDA_RELEASE_VERSION }}-amd64 --amend dgraph-lambda:${{ env.DGRAPH_LAMBDA_RELEASE_VERSION }}-arm64
+          docker manifest push dgraph-lambda:${{ env.DGRAPH_LAMBDA_RELEASE_VERSION }}
+          [[ "${{ inputs.latest }}" = true ]] && docker manifest create dgraph-lambda:latest --amend dgraph-lambda:${{ env.DGRAPH_LAMBDA_RELEASE_VERSION }}-amd64 --amend dgraph-lambda:${{ env.DGRAPH_LAMBDA_RELEASE_VERSION }}-arm64
+          [[ "${{ inputs.latest }}" = true ]] && docker manifest push dgraph-lambda:latest || true


### PR DESCRIPTION
## Problem ##
We are pushing amd and arm images using docker's buildx plugin which is nice and clean. However, we use manifests to push dgraph and dgraph:standalone images in the core repo which gives us much better control over the image build/push process. We should standardize this process across releases in other key repos like lambda as we build multi-arch support.

## Solution ##
Converting the cd-dgraph-lambda process to build and push using manifests