### PR TITLE
Add optional commitNow param to dql.mutate. Implement dql.commit.

### DIFF
--- a/src/dgraph.ts
+++ b/src/dgraph.ts
@@ -68,5 +68,33 @@ export class dql {
     return response.json();
   }
 
+  async commit(txn: {
+    start_ts: number;
+    hash: string;
+    preds: string[];
+    keys: string[];
+  }): Promise<GraphQLResponse> {
+    const headers: Record<string, string> = {};
+    headers["Content-Type"] = "application/json";
+    headers["X-Auth-Token"] = process.env.DGRAPH_TOKEN || "";
+    // add user access token (login to tenant) if defined
+    if (this.accessJWT && this.accessJWT != "") {
+      headers["X-Dgraph-AccessToken"] = this.accessJWT;
+    }
+    const { start_ts, hash, ...rest } = txn;
+    const response = await fetch(
+      `${process.env.DGRAPH_URL}/commit?startTs=${start_ts}&hash=${hash}`,
+      {
+        method: "POST",
+        headers: headers,
+        body: JSON.stringify(rest),
+      }
+    );
+    if (response.status !== 200) {
+      throw new Error("Failed to execute DQL Commit");
+    }
+    return response.json();
+  }
+
 }
 

--- a/src/dgraph.ts
+++ b/src/dgraph.ts
@@ -91,7 +91,7 @@ export class dql {
       }
     );
     if (response.status !== 200) {
-      throw new Error("Failed to execute DQL Commit");
+      throw new Error("Failed to commit transaction");
     }
     return response.json();
   }

--- a/src/dgraph.ts
+++ b/src/dgraph.ts
@@ -49,7 +49,7 @@ export class dql {
     return response.json();
   }
 
-  async mutate(mutate: string | Object): Promise<GraphQLResponse> {
+  async mutate(mutate: string | Object, commitNow: boolean = true): Promise<GraphQLResponse> {
     const headers: Record<string, string> = { };
     headers["Content-Type"] = typeof mutate === 'string' ? "application/rdf" : "application/json"
     headers["X-Auth-Token"] = process.env.DGRAPH_TOKEN || "";
@@ -57,7 +57,7 @@ export class dql {
     if (this.accessJWT && this.accessJWT!='') {
       headers["X-Dgraph-AccessToken"] = this.accessJWT;
     }
-    const response = await fetch(`${process.env.DGRAPH_URL}/mutate?commitNow=true`, {
+    const response = await fetch(`${process.env.DGRAPH_URL}/mutate?commitNow=${commitNow}`, {
       method: "POST",
       headers: headers,
       body: typeof mutate === 'string' ? mutate : JSON.stringify(mutate)


### PR DESCRIPTION
Currently, there is no option to utilize the commit endpoint within Lambda functions. As transactions play a crucial role in various Lambda operations, enabling access to the commit endpoint would be advantageous for all Lambda users.

The implementation of this feature is straightforward and does not pose a risk of breaking existing Lambda sources. This enhancement would greatly benefit Lambda users by providing a streamlined way to manage transactions within their functions.